### PR TITLE
ファイルないときの挙動の修正

### DIFF
--- a/lib/yamlutil.py
+++ b/lib/yamlutil.py
@@ -13,10 +13,13 @@ class yaml:
         yamlを読み込んでそのままDictとかListにします。
         読み込めなかった場合にはdefaultの値を返します。
         """
-        with open(self.path, 'r', encoding="utf-8_sig") as f:
-            data = y.safe_load(f)
-            if data != None:
-                return data
+        try:
+            with open(self.path, 'r', encoding="utf-8_sig") as f:
+                data = y.safe_load(f)
+                if data != None:
+                    return data
+                return default
+        except FileNotFoundError:
             return default
 
     def save_yaml(self, data: any):


### PR DESCRIPTION
ファイルが無い時に`with open`した挙動で`FileNotFoundError`を投げるらしいので、無い時は新しく`default`のオブジェクトを投げるように修正しました。

っていうか完全に挙動勘違いしてました（）